### PR TITLE
Doug/shuffle pins

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,22 @@
         "titleBar.activeForeground": "#e7e7e7",
         "titleBar.inactiveBackground": "#2d17a999",
         "titleBar.inactiveForeground": "#e7e7e799"
-    }
+    }, 
+    "micropico.pyIgnore": [
+        "**/.picowgo",
+        "**/.micropico",
+        "**/.vscode",
+        "**/.gitignore",
+        "**/.git",
+        "**/.DS_Store",
+        "**/project.pico-go",
+        "**/env",
+        "**/venv",
+        "**/.venv",
+        "**/.idea",
+        "**/.mypy_cache",
+        "**/client",
+        "**/.mypy_cache/3.10", 
+        "**/README.md"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -42,3 +42,12 @@ TODO: these are currently in a ppt, at some point I'll migrate to md and link fr
 
 ## Disclaimer
 There are hazards associated with any electronics project, and any light source. If you don't understand the risks, don't build it. If you're building this without my explicit supervision, I take no reponsibility etc etc. 
+
+## A tip to handle dependencies inside the project
+e.g. to access hardware modules that sit in `.\components` from a script that lives in `.\exercises`
+* Delete `.mypy_cache` folder from the project root - it'll come back again, so don't worry.
+* Or: depend on changes to `settings.json` to ensure that stuff like `.mypy_cache` doesn't get pushed to the microcontroller. 
+* Right click any file in the project in Explorer view and select "Upload project to Pico"
+* Should get confirmation of successful upload in lower right of VSCode window
+* Sometimes needs restart of VS Code to get this to work 🤷‍♂️
+* Note that [Thonny](https://thonny.org/) is a useful tool to browse what's actually on the Pico and to do any clearing up of old project files.

--- a/components/mcp41010_test.py
+++ b/components/mcp41010_test.py
@@ -5,9 +5,9 @@ from components.digital_pot.mcp41010 import MCP41010
 import time
 
 a = ADC(0)
-cs = Pin(17, Pin.OUT)
-s = SPI(0, sck=Pin(18), mosi=Pin(19), miso=Pin(16))
-m = MCP41010(s, cs)
+cs = Pin(1, Pin.OUT)
+s = SPI(0, sck=Pin(2), mosi=Pin(3), miso=Pin(0))
+m = MCP41010(s, cs) 
 
 potval: int = 0
 potval = m.set(potval)
@@ -20,7 +20,7 @@ try:
         # print("[ %5.3f %5.3f %5.3f ]" % (0.0, 3.3 * v / 65536, 3.3))
         potval = potval + direction
         potval = m.set(potval)
-        if potval == 128:
+        if potval == 255:
             direction = -1
         if potval == 0:
             direction = 1

--- a/components/neopixel_blink.py
+++ b/components/neopixel_blink.py
@@ -5,7 +5,7 @@ from utime import sleep
 N_PIXELS = 1
 ON_VALUE = 255
 
-nps = NeoPixel(Pin(4), N_PIXELS, bpp=3)
+nps = NeoPixel(Pin(15), N_PIXELS, bpp=3)
 # start off @ 50% brightness in red channel
 nps[0] = (128, 0, 0)
 


### PR DESCRIPTION
Choose different pins to drive LED and digital pot to reduce congestion around the bottom end of the breadboard